### PR TITLE
Expose expires_in param

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ passport.use(new SpotifyStrategy({
     clientSecret: client_secret,
     callbackURL: "http://localhost:8888/auth/spotify/callback"
   },
-  function(accessToken, refreshToken, profile, done) {
+  function(accessToken, refreshToken, expires_in, profile, done) {
     User.findOrCreate({ spotifyId: profile.id }, function (err, user) {
       return done(err, user);
     });

--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -30,14 +30,14 @@ passport.deserializeUser(function(obj, done) {
 
 // Use the SpotifyStrategy within Passport.
 //   Strategies in Passport require a `verify` function, which accept
-//   credentials (in this case, an accessToken, refreshToken, and spotify
-//   profile), and invoke a callback with a user object.
+//   credentials (in this case, an accessToken, refreshToken, expires_in 
+//   and spotify profile), and invoke a callback with a user object.
 passport.use(new SpotifyStrategy({
   clientID: appKey,
   clientSecret: appSecret,
   callbackURL: 'http://localhost:8888/callback'
   },
-  function(accessToken, refreshToken, profile, done) {
+  function(accessToken, refreshToken, expires_in, profile, done) {
     // asynchronous verification, for effect...
     process.nextTick(function () {
       // To keep the example simple, the user's spotify profile is returned to

--- a/lib/passport-spotify/strategy.js
+++ b/lib/passport-spotify/strategy.js
@@ -73,8 +73,9 @@ var util = require('util'),
             var results = JSON.parse(data);
             var access_token = results.access_token;
             var refresh_token = results.refresh_token;
+            var expires_in = results.expires_in;
             delete results.refresh_token;
-            callback(null, access_token, refresh_token, results); // callback results =-=
+            callback(null, access_token, refresh_token, expires_in, results); // callback results =-=
         }
     });
   };

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -120,6 +120,7 @@ describe('SpotifyStrategy', function() {
                     var data = JSON.stringify({
                         access_token: 'access_token',
                         refresh_token: 'refresh_token',
+                        expires_in: 'expires_in',
                         client_id: 'ABC123',
                         client_secret: 'secret',
                         something_random: 'randomness'
@@ -134,10 +135,11 @@ describe('SpotifyStrategy', function() {
             });
 
             it('should pass the data back', function(done) {
-                strategy._oauth2.getOAuthAccessToken('code', {}, function(err, accessToken, refreshToken, params) {
+                strategy._oauth2.getOAuthAccessToken('code', {}, function(err, accessToken, refreshToken, expires_in, params) {
                     should.not.exist(err);
                     accessToken.should.equal('access_token');
                     refreshToken.should.equal('refresh_token');
+                    expires_in.should.equal('expires_in');
                     done();
                 });
             });


### PR DESCRIPTION
This pull request exposes the 'expires_in' return param from spotify, which enables the use of refresh_token once 'expires_in' has lapsed.

https://beta.developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow

I also updated the README and example code to match.